### PR TITLE
Add Mentor Request Form

### DIFF
--- a/src/scenes/home/home.js
+++ b/src/scenes/home/home.js
@@ -12,6 +12,7 @@ import styles from './home.css';
 import Header from './header/header';
 import Landing from './landing/landing';
 import Footer from './footer/footer';
+import MentorRequest from './mentorRequest/mentorRequest';
 
 class Home extends Component {
   constructor(props) {
@@ -61,6 +62,7 @@ class Home extends Component {
           <Route path="/join" component={SignUp} />
           <Route path="/sign_up" component={SignUp} />
           <Route path="/thanks" component={Thanks} />
+          <Route path="/mentor-request" component={MentorRequest} />
         </div>
         <Footer />
       </div>

--- a/src/scenes/home/mentorRequest/mentorRequest.css
+++ b/src/scenes/home/mentorRequest/mentorRequest.css
@@ -1,0 +1,21 @@
+.mentorRequest {
+  width:100%;
+}
+
+.mentorRequestForm span {
+  padding: 10px 8px 30px 8px;
+  font-size:16px;
+}
+
+.mentorRequestForm {
+  max-width:500px;
+  margin:auto;
+  border: 1px solid rgb(92,105,122);
+  padding: 10px;
+  min-height:550px;
+}
+
+.joinButton {
+  align-self: flex-end;
+  margin-top: 10px;
+}

--- a/src/scenes/home/mentorRequest/mentorRequest.css
+++ b/src/scenes/home/mentorRequest/mentorRequest.css
@@ -19,3 +19,14 @@
   align-self: flex-end;
   margin-top: 10px;
 }
+
+.mentorRequestError {
+  background-color: #ffc2c2;
+  border-radius: 0.25rem;
+  color: red;
+  margin-bottom: 1rem;
+  max-width: 500px;
+  padding: 1rem;
+  text-align: center;
+  width: 100%;
+}

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
 import Form from 'shared/components/form/form';
+import FormButton from 'shared/components/form/formButton/formButton';
 import FormInput from 'shared/components/form/formInput/formInput';
 import FormSelect from 'shared/components/form/formSelect/formSelect';
 import { getServices, getMentors } from 'shared/utils/apiHelper';
 import Section from 'shared/components/section/section';
-import FormButton from 'shared/components/form/formButton/formButton';
-import { Redirect } from 'react-router-dom';
 import styles from './mentorRequest.css';
 
 
@@ -70,7 +70,7 @@ export default class MentorRequest extends Component {
     ]
 
   render() {
-    const { error } = this.state;
+    const { error, success } = this.state;
     return (
       <Section className={styles.mentorRequest} title="Mentor Service Request">
         { error && <div className={styles.mentorRequestError}>{error}</div> }
@@ -100,8 +100,8 @@ export default class MentorRequest extends Component {
           <p>Please provide us with any more info that may help in us in assigning a mentor to this request.</p>
           <FormInput id="additionalDetails" onChange={this.onDetailsChange} />
           <FormButton className={styles.joinButton} text="Request Mentor" onClick={this.handleOnClick} theme="red" />
-          {this.state.error && <span>There was an error requesting mentor: {this.state.error}</span>}
-          {this.state.success && <Redirect to="/thanks" />}
+          {error && <span>There was an error requesting mentor: {this.state.error}</span>}
+          {success && <Redirect to="/thanks" />}
         </Form>
       </Section>
     );

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -26,12 +26,21 @@ export default class MentorRequest extends Component {
     });
   }
 
+  onLanguageTypeChange = (language) => {
+    this.setState({
+      languageType: language
+    });
+  }
+
   render() {
     return (
       <div>
         <h1>Mentor Service Request</h1>
         <Form>
+          <h2>Slack Name</h2>
           <FormInput id="slackName" onChange={this.onSlackNameChange} />
+          <h2>Service</h2>
+          <p>Which one of our services would you like to book?</p>
           <select id="serviceType" value={this.state.serviceType} onChange={this.onServiceTypeChange}>
             <option value="voiceChat">General Guidance - Voice Chat</option>
             <option value="slackChat">General Guidance - Slack Chat</option>
@@ -40,6 +49,23 @@ export default class MentorRequest extends Component {
             <option value="mockInterview">Mock Interview</option>
             <option value="resumeReview">Resume Review</option>
           </select>
+          <h2>Language</h2>
+          <p>Do you need a mentor for a specific language?</p>
+          <select id="languageType" value={this.state.languageType} onChange={this.onLanguageTypeChange}>
+            <option value="javascript">Javascript</option>
+            <option value="ruby">Ruby</option>
+            <option value="python">Python</option>
+            <option value="java">Java</option>
+            <option value="dotnet">.NET</option>
+            <option value="htmlcss">HTML/CSS</option>
+          </select>
+          <h2>Mentor</h2>
+          <p>Would you like to pick a specific mentor?</p>
+          <select id="mentor" value={this.state.mentor} onChange={this.onMentorChange}>
+            <option value="namePlaceholder">Mentor Name</option>
+          </select>
+          <h2>Additional Details</h2>
+          <p>Please provide us with any more info that may help in us in assigning a mentor to this request.</p>
           <FormInput id="additionalDetails" onChange={this.onDetailsChange} />
 
         </Form>

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -14,13 +14,34 @@ export default class MentorRequest extends Component {
     });
   }
 
+  onDetailsChange = (details) => {
+    this.setState({
+      additionalDetails: details
+    });
+  }
+
+  onServiceTypeChange = (service) => {
+    this.setState({
+      serviceType: service
+    });
+  }
+
   render() {
     return (
       <div>
         <h1>Mentor Service Request</h1>
         <Form>
           <FormInput id="slackName" onChange={this.onSlackNameChange} />
+          <select id="serviceType" value={this.state.serviceType} onChange={this.onServiceTypeChange}>
+            <option value="voiceChat">General Guidance - Voice Chat</option>
+            <option value="slackChat">General Guidance - Slack Chat</option>
+            <option value="pairProgramming">Pair Programming</option>
+            <option value="codeReview">Code Review</option>
+            <option value="mockInterview">Mock Interview</option>
+            <option value="resumeReview">Resume Review</option>
+          </select>
           <FormInput id="additionalDetails" onChange={this.onDetailsChange} />
+
         </Form>
       </div>
     );

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -49,6 +49,12 @@ export default class MentorRequest extends Component {
     });
   }
 
+  onMentorChange = (mentor) => {
+    this.setState({
+      mentor
+    });
+  }
+
   setFetchError = () => {
     this.setState({ error: 'There was an error building the form. Please try again' });
   }

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -4,7 +4,10 @@ import FormInput from 'shared/components/form/formInput/formInput';
 import FormSelect from 'shared/components/form/formSelect/formSelect';
 import { getServices, getMentors } from 'shared/utils/apiHelper';
 import Section from 'shared/components/section/section';
+import FormButton from 'shared/components/form/formButton/formButton';
+import { Redirect } from 'react-router-dom';
 import styles from './mentorRequest.css';
+
 
 export default class MentorRequest extends Component {
   state = {
@@ -96,6 +99,9 @@ export default class MentorRequest extends Component {
           <h2>Additional Details</h2>
           <p>Please provide us with any more info that may help in us in assigning a mentor to this request.</p>
           <FormInput id="additionalDetails" onChange={this.onDetailsChange} />
+          <FormButton className={styles.joinButton} text="Request Mentor" onClick={this.handleOnClick} theme="red" />
+          {this.state.error && <span>There was an error requesting mentor: {this.state.error}</span>}
+          {this.state.success && <Redirect to="/thanks" />}
         </Form>
       </Section>
     );

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Form from 'shared/components/form/form';
 import FormInput from 'shared/components/form/formInput/formInput';
+import FormSelect from 'shared/components/form/formSelect/formSelect';
 import { getServices, getMentors } from 'shared/utils/apiHelper';
 import Section from 'shared/components/section/section';
 import styles from './mentorRequest.css';
@@ -10,7 +11,8 @@ export default class MentorRequest extends Component {
     additionalDetails: '',
     mentors: [],
     slackName: '',
-    services: []
+    services: [],
+    serviceType: ''
   };
 
   componentDidMount() {
@@ -55,6 +57,22 @@ export default class MentorRequest extends Component {
     });
   }
 
+  buildServiceOptions = () =>
+    this.state.services.map(service => ({ value: service, label: service }))
+
+  buildMentorOptions = () =>
+    this.state.mentors.map(mentor => ({ value: mentor.id, label: mentor.email }))
+
+  buildLanguageOptions = () =>
+    [
+      { value: 'javascript', label: 'Javascript' },
+      { value: 'ruby', label: 'Ruby' },
+      { value: 'python', label: 'Python' },
+      { value: 'java', label: 'Java' },
+      { value: 'dotnet', label: '.NET' },
+      { value: 'htmlcss', label: 'HTML/CSS' }
+    ]
+
   render() {
     return (
       <Section className={styles.mentorRequest} title="Mentor Service Request">
@@ -64,32 +82,25 @@ export default class MentorRequest extends Component {
             Each session is 30 minutes. If you think youll need more time
             please let us know in the additional comments field below.
           </span>
+
           <h2>Slack Name</h2>
           <FormInput id="slackName" placeholder="Slack username" onChange={this.onSlackNameChange} />
+
           <h2>Service</h2>
           <p>Which one of our services would you like to book?</p>
-          <select id="serviceType" value={this.state.serviceType} onChange={this.onServiceTypeChange}>
-            {this.state.services.map(service => <option value={service}>{service}</option>)}
-          </select>
+          <FormSelect id="serviceType" prompt="Choose service" options={this.buildServiceOptions()} onChange={this.onServiceTypeChange} />
+
           <h2>Language</h2>
           <p>Do you need a mentor for a specific language?</p>
-          <select id="languageType" value={this.state.languageType} onChange={this.onLanguageTypeChange}>
-            <option value="javascript">Javascript</option>
-            <option value="ruby">Ruby</option>
-            <option value="python">Python</option>
-            <option value="java">Java</option>
-            <option value="dotnet">.NET</option>
-            <option value="htmlcss">HTML/CSS</option>
-          </select>
+          <FormSelect id="languageType" options={this.buildLanguageOptions()} onChange={this.onLanguageTypeChange} prompt="Select language" />
+
           <h2>Mentor</h2>
           <p>Would you like to pick a specific mentor?</p>
-          <select id="mentor" value={this.state.mentor} onChange={this.onMentorChange}>
-            <option value="namePlaceholder">Mentor Name</option>
-          </select>
+          <FormSelect id="mentor" prompt="Choose mentor" options={this.buildMentorOptions()} onChange={this.onMentorChange} />
+
           <h2>Additional Details</h2>
           <p>Please provide us with any more info that may help in us in assigning a mentor to this request.</p>
           <FormInput id="additionalDetails" onChange={this.onDetailsChange} />
-
         </Form>
       </Section>
     );

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react';
+import Form from 'shared/components/form/form';
+import FormInput from 'shared/components/form/formInput/formInput';
+
+export default class MentorRequest extends Component {
+  state = {
+    additionalDetails: '',
+    slackName: ''
+  };
+
+  onSlackNameChange = (name) => {
+    this.setState({
+      slackName: name
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <h1>Mentor Service Request</h1>
+        <Form>
+          <FormInput id="slackName" onChange={this.onSlackNameChange} />
+          <FormInput id="additionalDetails" onChange={this.onDetailsChange} />
+        </Form>
+      </div>
+    );
+  }
+}

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import Form from 'shared/components/form/form';
 import FormInput from 'shared/components/form/formInput/formInput';
+import Section from 'shared/components/section/section';
+import styles from './mentorRequest.css';
 
 export default class MentorRequest extends Component {
   state = {
@@ -34,11 +36,15 @@ export default class MentorRequest extends Component {
 
   render() {
     return (
-      <div>
-        <h1>Mentor Service Request</h1>
-        <Form>
+      <Section className={styles.mentorRequest} title="Mentor Service Request">
+        <Form className={styles.mentorRequestForm}>
+          <span>
+            Please use this form to schedule a mentorship session.
+            Each session is 30 minutes. If you think youll need more time
+            please let us know in the additional comments field below.
+          </span>
           <h2>Slack Name</h2>
-          <FormInput id="slackName" onChange={this.onSlackNameChange} />
+          <FormInput id="slackName" placeholder="Slack username" onChange={this.onSlackNameChange} />
           <h2>Service</h2>
           <p>Which one of our services would you like to book?</p>
           <select id="serviceType" value={this.state.serviceType} onChange={this.onServiceTypeChange}>
@@ -69,7 +75,7 @@ export default class MentorRequest extends Component {
           <FormInput id="additionalDetails" onChange={this.onDetailsChange} />
 
         </Form>
-      </div>
+      </Section>
     );
   }
 }

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -18,7 +18,6 @@ export default class MentorRequest extends Component {
       this.setState({
         services
       });
-      console.log(services);
     }).catch(() => {
       alert('there was an error getting services');
     });
@@ -27,7 +26,6 @@ export default class MentorRequest extends Component {
       this.setState({
         mentors
       });
-      console.log(mentors);
     }).catch(() => {
       alert('there was an error getting mentors');
     });
@@ -71,12 +69,7 @@ export default class MentorRequest extends Component {
           <h2>Service</h2>
           <p>Which one of our services would you like to book?</p>
           <select id="serviceType" value={this.state.serviceType} onChange={this.onServiceTypeChange}>
-            <option value="voiceChat">General Guidance - Voice Chat</option>
-            <option value="slackChat">General Guidance - Slack Chat</option>
-            <option value="pairProgramming">Pair Programming</option>
-            <option value="codeReview">Code Review</option>
-            <option value="mockInterview">Mock Interview</option>
-            <option value="resumeReview">Resume Review</option>
+            {this.state.services.map(service => <option value={service}>{service}</option>)}
           </select>
           <h2>Language</h2>
           <p>Do you need a mentor for a specific language?</p>

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -4,7 +4,7 @@ import Form from 'shared/components/form/form';
 import FormButton from 'shared/components/form/formButton/formButton';
 import FormInput from 'shared/components/form/formInput/formInput';
 import FormSelect from 'shared/components/form/formSelect/formSelect';
-import { getServices, getMentors } from 'shared/utils/apiHelper';
+import * as ApiHelpers from 'shared/utils/apiHelper';
 import Section from 'shared/components/section/section';
 import styles from './mentorRequest.css';
 
@@ -16,11 +16,11 @@ export default class MentorRequest extends Component {
   };
 
   componentDidMount() {
-    getServices().then((services) => {
+    ApiHelpers.getServices().then((services) => {
       this.setState({ services });
     }).catch(this.setFetchError);
 
-    getMentors().then((mentors) => {
+    ApiHelpers.getMentors().then((mentors) => {
       this.setState({ mentors });
     }).catch(this.setFetchError);
   }
@@ -37,21 +37,9 @@ export default class MentorRequest extends Component {
     });
   }
 
-  onServiceTypeChange = (service) => {
+  onUpdateSelect = (name, event) => {
     this.setState({
-      serviceType: service
-    });
-  }
-
-  onLanguageTypeChange = (language) => {
-    this.setState({
-      languageType: language
-    });
-  }
-
-  onMentorChange = (mentor) => {
-    this.setState({
-      mentor
+      [name]: event.target.value
     });
   }
 
@@ -60,7 +48,7 @@ export default class MentorRequest extends Component {
   }
 
   buildServiceOptions = () =>
-    this.state.services.map(service => ({ value: service, label: service }))
+    this.state.services.map(service => ({ value: service.id, label: service.name }))
 
   buildMentorOptions = () =>
     this.state.mentors.map(mentor => ({ value: mentor.id, label: mentor.email }))
@@ -74,6 +62,19 @@ export default class MentorRequest extends Component {
       { value: 'dotnet', label: '.NET' },
       { value: 'htmlcss', label: 'HTML/CSS' }
     ]
+
+  handleOnClick = () => {
+    ApiHelpers.postRequest({
+      language: this.state.languageType,
+      additionalDetails: this.state.additionalDetails,
+      service: this.state.serviceType,
+      mentor: this.state.mentor
+    }).then(() => {
+      this.setState({ success: true });
+    }).catch(() => {
+      this.setState({ error: 'There was an error requesting a mentor.' });
+    });
+  }
 
   render() {
     const { error, success } = this.state;
@@ -92,21 +93,20 @@ export default class MentorRequest extends Component {
 
           <h2>Service</h2>
           <p>Which one of our services would you like to book?</p>
-          <FormSelect id="serviceType" prompt="Choose service" options={this.buildServiceOptions()} onChange={this.onServiceTypeChange} />
+          <FormSelect id="serviceType" prompt="Choose service" options={this.buildServiceOptions()} onChange={e => this.onUpdateSelect('serviceType', e)} />
 
           <h2>Language</h2>
           <p>Do you need a mentor for a specific language?</p>
-          <FormSelect id="languageType" options={this.buildLanguageOptions()} onChange={this.onLanguageTypeChange} prompt="Select language" />
+          <FormSelect id="languageType" options={this.buildLanguageOptions()} onChange={e => this.onUpdateSelect('languageType', e)} prompt="Select language" />
 
           <h2>Mentor</h2>
           <p>Would you like to pick a specific mentor?</p>
-          <FormSelect id="mentor" prompt="Choose mentor" options={this.buildMentorOptions()} onChange={this.onMentorChange} />
+          <FormSelect id="mentor" prompt="Choose mentor" options={this.buildMentorOptions()} onChange={e => this.onUpdateSelect('mentor', e)} />
 
           <h2>Additional Details</h2>
           <p>Please provide us with any more info that may help in us in assigning a mentor to this request.</p>
           <FormInput id="additionalDetails" onChange={this.onDetailsChange} />
           <FormButton className={styles.joinButton} text="Request Mentor" onClick={this.handleOnClick} theme="red" />
-          {error && <span>There was an error requesting mentor: {this.state.error}</span>}
           {success && <Redirect to="/thanks" />}
         </Form>
       </Section>

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -1,14 +1,37 @@
 import React, { Component } from 'react';
 import Form from 'shared/components/form/form';
 import FormInput from 'shared/components/form/formInput/formInput';
+import { getServices, getMentors } from 'shared/utils/apiHelper';
 import Section from 'shared/components/section/section';
 import styles from './mentorRequest.css';
 
 export default class MentorRequest extends Component {
   state = {
     additionalDetails: '',
-    slackName: ''
+    mentors: [],
+    slackName: '',
+    services: []
   };
+
+  componentDidMount() {
+    getServices().then((services) => {
+      this.setState({
+        services
+      });
+      console.log(services);
+    }).catch(() => {
+      alert('there was an error getting services');
+    });
+
+    getMentors().then((mentors) => {
+      this.setState({
+        mentors
+      });
+      console.log(mentors);
+    }).catch(() => {
+      alert('there was an error getting mentors');
+    });
+  }
 
   onSlackNameChange = (name) => {
     this.setState({

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -93,15 +93,30 @@ export default class MentorRequest extends Component {
 
           <h2>Service</h2>
           <p>Which one of our services would you like to book?</p>
-          <FormSelect id="serviceType" prompt="Choose service" options={this.buildServiceOptions()} onChange={e => this.onUpdateSelect('serviceType', e)} />
+          <FormSelect
+            id="serviceType"
+            prompt="Choose service"
+            options={this.buildServiceOptions()}
+            onChange={e => this.onUpdateSelect('serviceType', e)}
+          />
 
           <h2>Language</h2>
           <p>Do you need a mentor for a specific language?</p>
-          <FormSelect id="languageType" options={this.buildLanguageOptions()} onChange={e => this.onUpdateSelect('languageType', e)} prompt="Select language" />
+          <FormSelect
+            id="languageType"
+            options={this.buildLanguageOptions()}
+            onChange={e => this.onUpdateSelect('languageType', e)}
+            prompt="Select language"
+          />
 
           <h2>Mentor</h2>
           <p>Would you like to pick a specific mentor?</p>
-          <FormSelect id="mentor" prompt="Choose mentor" options={this.buildMentorOptions()} onChange={e => this.onUpdateSelect('mentor', e)} />
+          <FormSelect
+            id="mentor"
+            prompt="Choose mentor"
+            options={this.buildMentorOptions()}
+            onChange={e => this.onUpdateSelect('mentor', e)}
+          />
 
           <h2>Additional Details</h2>
           <p>Please provide us with any more info that may help in us in assigning a mentor to this request.</p>

--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -8,29 +8,18 @@ import styles from './mentorRequest.css';
 
 export default class MentorRequest extends Component {
   state = {
-    additionalDetails: '',
     mentors: [],
-    slackName: '',
-    services: [],
-    serviceType: ''
+    services: []
   };
 
   componentDidMount() {
     getServices().then((services) => {
-      this.setState({
-        services
-      });
-    }).catch(() => {
-      alert('there was an error getting services');
-    });
+      this.setState({ services });
+    }).catch(this.setFetchError);
 
     getMentors().then((mentors) => {
-      this.setState({
-        mentors
-      });
-    }).catch(() => {
-      alert('there was an error getting mentors');
-    });
+      this.setState({ mentors });
+    }).catch(this.setFetchError);
   }
 
   onSlackNameChange = (name) => {
@@ -57,6 +46,10 @@ export default class MentorRequest extends Component {
     });
   }
 
+  setFetchError = () => {
+    this.setState({ error: 'There was an error building the form. Please try again' });
+  }
+
   buildServiceOptions = () =>
     this.state.services.map(service => ({ value: service, label: service }))
 
@@ -74,8 +67,10 @@ export default class MentorRequest extends Component {
     ]
 
   render() {
+    const { error } = this.state;
     return (
       <Section className={styles.mentorRequest} title="Mentor Service Request">
+        { error && <div className={styles.mentorRequestError}>{error}</div> }
         <Form className={styles.mentorRequestForm}>
           <span>
             Please use this form to schedule a mentorship session.

--- a/src/shared/components/form/formInput/formInput.js
+++ b/src/shared/components/form/formInput/formInput.js
@@ -25,7 +25,7 @@ class FormInput extends Component {
   validate = (text) => {
     if (this.props.validateFunc) {
       return this.props.validateFunc(text);
-    } else if (text.length > 0) {
+    } else if (text.length > 0 && this.props.validationRegex) {
       return this.props.validationRegex.test(text);
     }
     return true;

--- a/src/shared/components/form/formSelect/formSelect.js
+++ b/src/shared/components/form/formSelect/formSelect.js
@@ -1,0 +1,39 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+export default class FormSelect extends Component {
+  buildOptions = () => {
+    const { prompt, options } = this.props;
+    const opts = [];
+
+    if (prompt) {
+      opts.push(<option key="prompt" value="">{ prompt }</option>);
+    }
+    options.forEach(option => opts.push(<option key={option.value} value={option.value}>{option.label}</option>));
+    return opts;
+  }
+
+  render() {
+    return (
+      <select id={this.props.id} onChange={this.props.onChange}>
+        {this.buildOptions()}
+      </select>
+    );
+  }
+}
+
+FormSelect.propTypes = {
+  prompt: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    label: PropTypes.string.isRequired
+  })).isRequired,
+  onChange: PropTypes.func,
+  id: PropTypes.string
+};
+
+FormSelect.defaultProps = {
+  onChange: () => {},
+  prompt: null,
+  id: null
+};

--- a/src/shared/utils/apiHelper.js
+++ b/src/shared/utils/apiHelper.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import config from 'config/environment';
+import Cookies from 'universal-cookie';
 
 function makeGenericGet(endpoint) {
   return axios.get(`${config.backendUrl}/${endpoint}`).then(({ data }) => data);
@@ -8,3 +9,25 @@ function makeGenericGet(endpoint) {
 export const getServices = () => makeGenericGet('services');
 
 export const getMentors = () => makeGenericGet('mentors');
+
+export const setAuthorizationHeader = () => {
+  const cookies = new Cookies();
+  return {
+    Authorization: `bearer ${cookies.get('token')}`
+  };
+};
+
+export function postRequest({ language, additionalDetails, mentor, service }) {
+  const authHeader = setAuthorizationHeader();
+
+  return axios.post(`${config.backendUrl}/requests`, {
+    request: {
+      details: additionalDetails,
+      requested_mentor_id: mentor,
+      service_id: service,
+      language
+    }
+  }, {
+    headers: authHeader
+  });
+}

--- a/src/shared/utils/apiHelper.js
+++ b/src/shared/utils/apiHelper.js
@@ -1,0 +1,10 @@
+import axios from 'axios';
+import config from 'config/environment';
+
+function makeGenericGet(endpoint) {
+  return axios.get(`${config.backendUrl}/${endpoint}`).then(({ data }) => data);
+}
+
+export const getServices = () => makeGenericGet('services');
+
+export const getMentors = () => makeGenericGet('mentors');

--- a/src/shared/utils/apiHelper.js
+++ b/src/shared/utils/apiHelper.js
@@ -2,20 +2,23 @@ import axios from 'axios';
 import config from 'config/environment';
 import Cookies from 'universal-cookie';
 
-function makeGenericGet(endpoint) {
-  return axios.get(`${config.backendUrl}/${endpoint}`).then(({ data }) => data);
-}
-
-export const getServices = () => makeGenericGet('services');
-
-export const getMentors = () => makeGenericGet('mentors');
-
 export const setAuthorizationHeader = () => {
   const cookies = new Cookies();
   return {
     Authorization: `bearer ${cookies.get('token')}`
   };
 };
+
+function makeGenericGet(endpoint) {
+  const authHeader = setAuthorizationHeader();
+  return axios.get(`${config.backendUrl}/${endpoint}`, {
+    headers: authHeader
+  }).then(({ data }) => data);
+}
+
+export const getServices = () => makeGenericGet('services');
+
+export const getMentors = () => makeGenericGet('mentors');
 
 export function postRequest({ language, additionalDetails, mentor, service }) {
   const authHeader = setAuthorizationHeader();


### PR DESCRIPTION
Adds a form to request a mentor, heavily based off of the airtable page, and heavily dependent on the backend to fetch the services provided and a list of mentors.

Uses the auth token in the cookie to set an authorization header to make the POST request to create the request