### PR TITLE
Add more session data to cookies

### DIFF
--- a/src/shared/components/login/login.js
+++ b/src/shared/components/login/login.js
@@ -29,9 +29,13 @@ class Login extends Component {
     this.setState({ password: value, passwordValid: valid });
   }
 
-  setUserAuthCookie = (token) => {
+  setUserAuthCookie = ({ token, user }) => {
     const cookies = new Cookies();
     cookies.set('token', token, { path: '/' });
+    cookies.set('firstName', user.first_name, { path: '/' });
+    cookies.set('lastName', user.last_name, { path: '/' });
+    cookies.set('slackName', user.slack_name, { path: '/' });
+    cookies.set('mentor', user.mentor, { path: '/' });
   }
 
   isFormValid = () => this.state.emailValid && this.state.passwordValid
@@ -45,7 +49,7 @@ class Login extends Component {
           password: this.state.password
         }
       }).then(({ data }) => {
-        this.setUserAuthCookie(data.token);
+        this.setUserAuthCookie(data);
         this.setState({ authenticated: true });
       }).catch((response) => {
         const error = _.get(response, 'response.data.error');


### PR DESCRIPTION
This adds cookies for more of the data that is sent back from the new session request so we can use it to optionally display links and pre-fill forms.

Two other approaches I can think of are storing this in local storage, and storing this is a 'global state' with redux.

Local storage can be cleared by the browser and may not be available to some browsers. Introducing redux could cause more confusion than it's worth.

I'm open to suggestions for any other options.